### PR TITLE
Qdrant Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ There are various dependencies, based on usage:
 # Additional engines/components
 pip install .[faiss-cpu]           # CPU-based Faiss
 pip install .[faiss-gpu]           # GPU-based Faiss
+pip install .[qdrant]              # Qdrant support
 pip install libs/colbert           # ColBERT/PLAID indexing engine
 pip install .[image-generation]    # Stable diffusion library
 pip install .[knowledge_graph]     # spacy and KG libraries

--- a/config/store/qdrant.yaml
+++ b/config/store/qdrant.yaml
@@ -1,0 +1,11 @@
+type: QdrantDocumentStore
+url: localhost
+port: 6333
+index: my_index
+embeddings_dim: 768
+similarity: dot_product
+hnsw_config:
+  m: 64
+  ef_construct: 20
+recreate_index: false    # set to true to generate new index
+timeout: 60

--- a/examples/qdrant_document_store.ipynb
+++ b/examples/qdrant_document_store.ipynb
@@ -1,0 +1,196 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from fastrag.stores import QdrantDocumentStore\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Qdrant Vector Store\n",
+    "\n",
+    "This is an example of using the [Qdrant](https://qdrant.tech/) vector store with fastRAG. This is done using the dependency `qdrant_haystack` and `qdrant_client` python connector. We assume you have a running server, e.g. by calling `docker run -p 6333:6333 qdrant/qdrant` locally. \n",
+    "\n",
+    "Two important settings are the dimension of the vectors and HNSW parameters. Qdrant uses HNSW index for faster search, with a tradeoff between accuracy and latency. In general, higher numbers mean better accuracy, lower latency and larger RAM usage. \n",
+    "\n",
+    "The parameters are specified when connecting the server and creating a new index; these cannot be changed after the index was created. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "dim = 100\n",
+    "index_name = \"test_hnsw\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating an Index\n",
+    "\n",
+    "Need to specify the location of the Qdrant service, vector dimension, index name, similarity metric and optionally the HNSW configuration. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "q = QdrantDocumentStore(url=\"http://localhost:6333\",\n",
+    "                        embedding_dim=dim,\n",
+    "                        timeout=60,\n",
+    "                        index=index_name,\n",
+    "                        embedding_field=\"embedding\",\n",
+    "                        hnsw_config={\"m\": 128, \"ef_construct\": 100},\n",
+    "                        similarity='dot_product',\n",
+    "                        recreate_index=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Insertion and Searching of Documents\n",
+    "\n",
+    "We'll create a few documents; they must have an `id`, `content` and `embedding` keys but could contain more data such as text titles. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "docs = [{\"id\": 1, \"content\": \"I like to go to the beach\", \"embedding\": np.ones(dim)},\n",
+    "        {\"id\": 2, \"content\": \"Where is my hat?\", \"embedding\": np.ones(dim) * 2},\n",
+    "        {\"id\": 3, \"content\": \"GPT4 is very nice\", \"embedding\": np.ones(dim) * 3},]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Writing the documents to index with batching; deduplication of documents is on by default. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "500it [00:00, 598.14it/s]                                                                                                                                                                                                        \n"
+     ]
+    }
+   ],
+   "source": [
+    "q.write_documents(docs, index_name, batch_size=500)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q.get_document_count(index=index_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Query by embedding\n",
+    "Need to provide a vector and `top_k` value. In general can also query by text search which we won't show here. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<Document: {'content': 'GPT4 is very nice', 'content_type': 'text', 'score': 0.9525741268224334, 'meta': {}, 'id_hash_keys': ['content'], 'embedding': '<embedding of shape (100,)>', 'id': '3'}>]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q.query_by_embedding(np.ones(dim), top_k=1, index=index_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "fastrag",
+   "language": "python",
+   "name": "fastrag"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/fastrag/__init__.py
+++ b/fastrag/__init__.py
@@ -4,7 +4,7 @@ from haystack.pipelines import Pipeline
 from fastrag import image_generators, kg_creators, rankers, readers, retrievers, stores
 from fastrag.utils import add_timing_to_pipeline
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 
 def load_pipeline(config_path: str) -> Pipeline:

--- a/fastrag/rankers/colbert.py
+++ b/fastrag/rankers/colbert.py
@@ -21,7 +21,6 @@ class ColBERTRanker(BaseRanker):
         use_gpu: bool = False,
         devices: Optional[List[Union[int, str, torch.device]]] = None,
     ):
-
         self.top_k = top_k
 
         if devices is not None:
@@ -83,7 +82,6 @@ class ColBERTRanker(BaseRanker):
         top_k: Optional[int] = None,
         batch_size: Optional[int] = None,
     ) -> List[List[Document]]:
-
         if top_k is None:
             top_k = self.top_k
 

--- a/fastrag/retrievers/colbert.py
+++ b/fastrag/retrievers/colbert.py
@@ -35,7 +35,6 @@ class ColBERTRetriever(BaseRetriever):
     def retrieve(
         self, query: str, top_k: Optional[int] = None, filters=None, **kwargs
     ) -> List[Document]:
-
         if filters:
             logger.info(f"Filters are not implemented for ColBERT/PLAID.")
 
@@ -54,7 +53,6 @@ class ColBERTRetriever(BaseRetriever):
         filters=None,
         **kwargs,
     ) -> List[List[Document]]:
-
         if filters:
             logger.info(f"Filters are not implemented for ColBERT/PLAID.")
 

--- a/fastrag/stores/__init__.py
+++ b/fastrag/stores/__init__.py
@@ -3,3 +3,4 @@ from fastrag.utils import safe_import
 FaissStore = safe_import("fastrag.stores.faiss", "FaissStore")
 FastRAGFAISSStore = safe_import("fastrag.stores.faiss", "FastRAGFAISSStore")
 PLAIDDocumentStore = safe_import("fastrag.stores.plaid", "PLAIDDocumentStore")
+QdrantDocumentStore = safe_import("qdrant_haystack", "QdrantDocumentStore")

--- a/fastrag/stores/faiss.py
+++ b/fastrag/stores/faiss.py
@@ -32,7 +32,6 @@ class FastRAGFAISSStore(FAISSDocumentStore):
         ef_construction: int = 80,
         validate_index_sync: bool = True,
     ):
-
         if faiss_index_path is None:
             try:
                 file_path = sql_url.split("sqlite:///")[1]

--- a/fastrag/stores/plaid.py
+++ b/fastrag/stores/plaid.py
@@ -46,7 +46,6 @@ class PLAIDDocumentStore(BaseDocumentStore):
         query_maxlen=60,
         kmeans_niters=4,
     ):
-
         super().__init__()
         self.index_path = index_path
         self.checkpoint_path = checkpoint_path

--- a/fastrag/ui/webapp.py
+++ b/fastrag/ui/webapp.py
@@ -64,7 +64,6 @@ def set_state_if_absent(key, value):
 
 
 def main():
-
     st.set_page_config(page_title="fastRAG Demo", page_icon="")
 
     with open("fastrag/ui/style.css", "r") as f:
@@ -241,7 +240,6 @@ This is a demo of a generative Q&A pipeline, using the fastRAG package.
         components.html(source_code, height=700, width=700)
 
     if st.session_state.images:
-
         image_markdown = ""
         for image_data_index, image_data in enumerate(st.session_state.images):
             image_content = image_data["image_content"]

--- a/fastrag/ui/webapp_summarization.py
+++ b/fastrag/ui/webapp_summarization.py
@@ -72,7 +72,6 @@ def set_state_if_absent(key, value):
 
 
 def main():
-
     st.set_page_config(
         page_title="fastRAG Demo", page_icon="https://haystack.deepset.ai/img/HaystackIcon.png"
     )
@@ -281,7 +280,6 @@ This is a demo of a generative Summarization pipeline, using the fastRAG package
                 return
 
     if st.session_state.images:
-
         image_markdown = ""
         for image_data_index, image_data in enumerate(st.session_state.images):
             image_content = image_data["image_content"]
@@ -302,7 +300,6 @@ This is a demo of a generative Summarization pipeline, using the fastRAG package
         display_runtime_plot(st.session_state.raw_json)
 
     if st.session_state.results:
-
         st.write("## Summary:")
 
         for count, result in enumerate(st.session_state.results):

--- a/libs/colbert/colbert/modeling/colbert.py
+++ b/libs/colbert/colbert/modeling/colbert.py
@@ -147,6 +147,7 @@ class ColBERT(BaseColBERT):
 
 # TODO: In Query/DocTokenizer, use colbert.raw_tokenizer
 
+
 # TODO: The masking below might also be applicable in the kNN part
 def colbert_score_reduce(scores_padded, D_mask, config: ColBERTConfig):
     D_padding = ~D_mask.view(scores_padded.size(0), scores_padded.size(1)).bool()

--- a/scripts/indexing/README.md
+++ b/scripts/indexing/README.md
@@ -19,13 +19,24 @@ For creating a FAISS-based dense index with DPR as an embedder/retriver, the fol
 
 ```sh
 python scripts/indexing/create_faiss.py \
-    --store config/store/faiss-haystack.yaml \
+    --store config/store/faiss.yaml \
     --data config/data/wikipedia_w100_hfdataset.yaml \
-    --embedder config/data/retriever/dpr.yaml \
+    --embedder config/retriever/dpr.yaml \
     --index-save-path <save path>
 ```
 
-**3. PLAID**:
+**3. Qdrant**:
+
+For creating a [Qdrant](https://qdrant.tech/)-based dense index with DPR as an embedder/retriver, the following script can be used:
+
+```sh
+python scripts/indexing/create_qdrant.py \
+    --store config/store/qdrant.yaml \
+    --data config/data/wikipedia_w100_hfdataset.yaml \
+    --embedder config/embedder/dpr.yaml
+```
+
+**4. PLAID**:
 
 PLAID (Based on [this](https://doi.org/10.48550/arXiv.2205.09707) paper) is a dense retrieval index engine that stores token vectors using an efficient algorithm. PLAID must be used with dense token embedder such as ColBERT which can embed tokens and utlizes a token-to-token ranking similarity method for ranking documents.
 More info on PLAID can be found in our [models](../../models) page.

--- a/scripts/indexing/create_qdrant.py
+++ b/scripts/indexing/create_qdrant.py
@@ -1,0 +1,42 @@
+import argparse
+import logging
+from pathlib import Path
+
+from fastrag.utils import init_cls, init_haystack_cls, load_yaml
+
+logger = logging.getLogger(__name__)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser("Create an index using Qdrant as a backend")
+    parser.add_argument("--store", type=Path, required=True)
+    parser.add_argument("--data", type=Path, required=True)
+    parser.add_argument("--embedder", type=Path, required=True)
+    parser.add_argument("--batch_size", type=int, required=False)
+
+    args = parser.parse_args()
+
+    store_params = load_yaml(args.store)
+    data_params = load_yaml(args.data)
+    emb_params = load_yaml(args.embedder)
+
+    store_cls = store_params.pop("type")
+    store = init_haystack_cls(store_cls, store_params)
+    logger.info("Loaded store backend")
+
+    data_cls = data_params.pop("type")
+    data = init_cls(data_cls, data_params)
+    logger.info("Done loading dataset")
+
+    logger.info("Indexing documents")
+    for docs in data:
+        store.write_documents(docs, batch_size=args.batch_size or 100)
+    logger.info("Done.")
+
+    logger.info("Loading Embedder")
+    emb_cls = emb_params.pop("type")
+    emb_params["document_store"] = store
+    emb = init_haystack_cls(emb_cls, emb_params)
+
+    logger.info("Encoding vectors")
+    store.update_embeddings(emb, batch_size=emb_params["batch_size"])
+    logger.info("Done.")

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 packages = find:
 
 install_requires =
-    farm-haystack==1.12.2
+    farm-haystack==1.13.2
     pandas
     tqdm
     numba
@@ -38,6 +38,9 @@ faiss-gpu =
 
 faiss-cpu =
     faiss-cpu==1.7.2
+
+qdrant =
+    qdrant_haystack>=0.0.4
 
 image-generation =
     diffusers


### PR DESCRIPTION
- Using 3rd party package `qdrant_haystack`.
- Install using `pip install .[qdrant]`.
- New document store called `QdrantDocumentStore`.
- New `qdrant.yaml` config example.
- Example notebook `fastRAG/examples/qdrant_document_store.ipynb`.
- Added `create_qdrant.py` index creation script + README.
- Version bump to `1.1.0`.