### PR TITLE
Return score when bi-directional ranker is called. 

### DIFF
--- a/fastrag/rankers/bi_encoder_ranker.py
+++ b/fastrag/rankers/bi_encoder_ranker.py
@@ -109,5 +109,9 @@ class BiEncoderSimilarityRanker:
         doc_vectors = torch.tensor([doc.embedding for doc in documents_with_vectors])
         scores = torch.tensor(query_vector) @ doc_vectors.T  ## perhaps need to break it into chunks
         scores = scores.reshape(len(documents))
+        # Store scores in documents_with_vectors
+        for doc, score in zip(documents_with_vectors, scores.tolist()):
+            doc.metadata["score"] = score
+
         indices = scores.cpu().sort(descending=True).indices
         return {"documents": [documents_with_vectors[i.item()] for i in indices[:top_k]]}

--- a/fastrag/rankers/bi_encoder_ranker.py
+++ b/fastrag/rankers/bi_encoder_ranker.py
@@ -110,8 +110,8 @@ class BiEncoderSimilarityRanker:
         scores = torch.tensor(query_vector) @ doc_vectors.T  ## perhaps need to break it into chunks
         scores = scores.reshape(len(documents))
         # Store scores in documents_with_vectors
-        for doc, score in zip(documents_with_vectors, scores.tolist()):
-            doc.metadata["score"] = score
+        for doc, score in zip(documents_with_vectors, scores.tolist()):            
+            doc.score = score
 
         indices = scores.cpu().sort(descending=True).indices
         return {"documents": [documents_with_vectors[i.item()] for i in indices[:top_k]]}

--- a/fastrag/rankers/colbert.py
+++ b/fastrag/rankers/colbert.py
@@ -70,6 +70,8 @@ class ColBERTRanker:
         # however scores are different than when calculated at query time.
         # It's due to quantization differences when recovering the embeddings.
         scores = torch.einsum("bwd,qvd -> bqwv", query_emb, tensor * masks).max(-1).values.sum(-1)
+        for doc, score in zip(documents, scores.tolist()):
+            doc.metadata["score"] = score
 
         indices = scores.cpu().sort(descending=True).indices[0]
         return {"documents": [documents[i.item()] for i in indices[:top_k]]}

--- a/fastrag/rankers/colbert.py
+++ b/fastrag/rankers/colbert.py
@@ -71,7 +71,7 @@ class ColBERTRanker:
         # It's due to quantization differences when recovering the embeddings.
         scores = torch.einsum("bwd,qvd -> bqwv", query_emb, tensor * masks).max(-1).values.sum(-1)
         for doc, score in zip(documents, scores.tolist()):
-            doc.metadata["score"] = score
+            doc.score = score
 
         indices = scores.cpu().sort(descending=True).indices[0]
         return {"documents": [documents[i.item()] for i in indices[:top_k]]}


### PR DESCRIPTION
**Fix for the issue discussed in [this comment](https://github.com/IntelLabs/fastRAG/issues/62#issuecomment-2343752239)**

In bi-encoder rankers, the document scores were not being attached properly. This PR populates the documents with their corresponding scores, enabling downstream filtering.
