### PR TITLE
Relax dependencies, add Streaming Callback

### DIFF
--- a/fastrag/__init__.py
+++ b/fastrag/__init__.py
@@ -1,4 +1,4 @@
 ### Essential imports for loading components and modifications to original Haystack components
 from fastrag import generators, rankers, retrievers, stores
 
-__version__ = "3.0.1"
+__version__ = "3.0.3"

--- a/fastrag/generators/openvino.py
+++ b/fastrag/generators/openvino.py
@@ -1,6 +1,7 @@
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Callable, Dict, List, Literal, Optional
 
 from haystack.components.generators import HuggingFaceLocalGenerator
+from haystack.dataclasses import StreamingChunk
 from haystack.lazy_imports import LazyImport
 from haystack.utils import ComponentDevice, Secret
 from transformers import AutoConfig, AutoTokenizer
@@ -48,6 +49,7 @@ class OpenVINOGenerator(HuggingFaceLocalGenerator):
         generation_kwargs: Optional[Dict[str, Any]] = None,
         huggingface_pipeline_kwargs: Optional[Dict[str, Any]] = None,
         stop_words: Optional[List[str]] = None,
+        streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
     ):
         """
         Creates an instance of a OpenVINOGenerator.
@@ -84,6 +86,7 @@ class OpenVINOGenerator(HuggingFaceLocalGenerator):
             If you provide this parameter, you should not specify the `stopping_criteria` in `generation_kwargs`.
             For some chat models, the output includes both the new text and the original prompt.
             In these cases, it's important to make sure your prompt has no stop words.
+        :param streaming_callback: An optional callable for handling streaming responses.
         """
         ov_import.check()
         super().__init__(
@@ -94,6 +97,7 @@ class OpenVINOGenerator(HuggingFaceLocalGenerator):
             generation_kwargs=generation_kwargs,
             huggingface_pipeline_kwargs=huggingface_pipeline_kwargs,
             stop_words=stop_words,
+            streaming_callback=streaming_callback,
         )
         self.model = model
         self.compressed_model_dir = compressed_model_dir

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [options]
 install_requires =
-    haystack-ai==2.1.2
+    haystack-ai>=2.1.2
     transformers>=4.35.2
     datasets
     evaluate
@@ -10,14 +10,14 @@ install_requires =
     numba
     openpyxl
     numpy
-    protobuf==3.20.2
+    protobuf>=3.20.2
     ujson
     accelerate
     fastapi
     uvicorn
-    Pillow==10.1.0
-    chainlit==1.0.506
-    sentence-transformers==2.3.0
+    Pillow>=10.1.0
+    chainlit>=1.0.506
+    sentence-transformers>=2.3.0
     events
 
 [options.extras_require]


### PR DESCRIPTION
Hi, so I am trying to make a RAG app with fastRAG.
But the dependency definition of fastRAG is causing conflicts with other dependencies.
For example, did `pip install` with this `requirement.txt` fails:

```text
haystack-ai==2.1.2
fastrag[openvino]==3.0.2
fastembed-haystack==1.3.0
qdrant-haystack==3.8.1
transformers[torch]==4.46.2
pypdf==5.1.0
fastapi==0.110.1
uvicorn[standard]==0.25.0
```

It's usually about `Pillow` and `protobuf`.
So, forked the lib, relaxed the dependencies, rebuilt it, and installed it in my project.
It is still working, but I only tried the OpenVINOGenerator feature.

So, proposing this change to allow better compatibility with other libs!